### PR TITLE
Patch for Shoot and Turn Method

### DIFF
--- a/fh_ac_ai_gym/wumpus/WumpusWorld.py
+++ b/fh_ac_ai_gym/wumpus/WumpusWorld.py
@@ -109,13 +109,13 @@ class Wumpus_World:
         a_d = self.state.agent_direction
         a_l, w_l = self.state.agent_location, self.state.wumpus_location 
         if a_d == Direction.WEST:
-            if a_l.x < w_l.x and a_l.y == w_l.y:
+            if a_l.x > w_l.x and a_l.y == w_l.y:
                 self.__kill_wumpus()
         elif a_d == Direction.SOUTH:
             if a_l.x == w_l.x and a_l.y > w_l.y:
                 self.__kill_wumpus()
         elif a_d == Direction.EAST:
-            if a_l.x > w_l.x and a_l.y == w_l.y:
+            if a_l.x < w_l.x and a_l.y == w_l.y:
                 self.__kill_wumpus()
         elif a_d == Direction.NORTH:
             if a_l.x == w_l.x and a_l.y < w_l.y:
@@ -139,7 +139,7 @@ class Wumpus_World:
             self.state.agent_direction = Direction((self.state.agent_direction.value -1) % len(Direction))
         elif action == Action.TURNRIGHT:
             self.state.agent_direction = Direction((self.state.agent_direction.value +1) % len(Direction))
-            
+        self.percept.bump = False    
 
     def go_forward(self):
         a_l = self.state.agent_location


### PR DESCRIPTION
Applied fix in the shoot method  and in the Bump method ( bump percept remains true after player has turned around )

Shoot method: 
Shoot does not work sideways due to the fact that the condition in the if-else statement is swapped. 

When we are facing WEST and we shoot, the wumpus should be on our LEFT, which means we should be on the RIGHT side of the wumpus ( a_l.x > w_l.x ). But, in the code it states a_l.x < w_l.x ( indicating that we are on the LEFT side of the wumpus )

It also applies to the EAST direction.

Bump method: 
The "bump" variable is staying "true" after you turn around after bumping into a wall.
 I would recommend adding "self.percept.bump = False" to the "turn"-Method 